### PR TITLE
Support for new MasterCard series "2" numbers

### DIFF
--- a/src/service/payment.js
+++ b/src/service/payment.js
@@ -49,7 +49,7 @@ angular.module('payment.service', [])
                     luhn: true
                 }, {
                     type: 'mastercard',
-                    pattern: /^5[1-5]/,
+                    pattern: /^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)/,
                     format: defaultFormat,
                     length: [16],
                     cvcLength: [3],


### PR DESCRIPTION
From Mastercard: 

Mastercard is adding a new "2" series to their bank identification numbers (BINs) to support the expanding payments industry.  BINs are the first 6 digits of a credit card number used to identify the institution that issued the card.  The "2" series BINs will range from 222100 to 272099, with the same rules and impact as the existing MasterCard 51-55 BIN ranges.

Software vendors are responsible for complying with the MasterCard mandate to support the new "2" series BIN range by October 14, 2016, in addition to the existing "5" series.

MasterCard will be issuing the "2" series cards beginning July, 2017.
